### PR TITLE
Update 14_object_assigned_by_reference.php

### DIFF
--- a/PHP/TestabilityPatterns/14_object_assigned_by_reference/14_object_assigned_by_reference.php
+++ b/PHP/TestabilityPatterns/14_object_assigned_by_reference/14_object_assigned_by_reference.php
@@ -3,7 +3,7 @@
 	    public $prop;
     };
     $x = "safe";
-    $obj = "abc";
+    $obj = new myclass();
     $obj->prop = &$x;
     $x = $_GET["p1"];
     echo $obj->prop;


### PR DESCRIPTION
Hi there, 

There is a slight mistake in the line 6. I believe that it should be `$obj = new myclass();` instead of `$obj = "abc";`, because the latter one is not syntax-correct. 

Best, 
Sam